### PR TITLE
Start ESC with minimum throttle

### DIFF
--- a/app/src/motor_control.c
+++ b/app/src/motor_control.c
@@ -21,7 +21,14 @@ void changer_impulsion(uint16_t pulse) {
 
 bool init_motors(void) {
     configure_timer_pwm();
-    HAL_Delay(3000);                 // Attendre les bips de démarrage usine
-    changer_impulsion(ESC_PULSE_MAX); // Ralenti
+    changer_impulsion(ESC_PULSE_MIN);      // Gaz minimum au démarrage
+    HAL_Delay(3000);                       // Attendre les bips d'initialisation
+
+    // Augmente progressivement la largeur d'impulsion jusqu'au ralenti
+    for (uint16_t pulse = ESC_PULSE_MIN; pulse <= ESC_PULSE_MAX; pulse += 5) {
+        changer_impulsion(pulse);
+        HAL_Delay(20);
+    }
+    changer_impulsion(ESC_PULSE_MAX); // Ralenti final
     return true;
 }


### PR DESCRIPTION
## Summary
- ramp ESC pulse output from `ESC_PULSE_MIN` to `ESC_PULSE_MAX` during motor init

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68407a601ad48333a694f1ddbafd240a